### PR TITLE
Configure k8s service load_balancer_source_ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2019-11-13
+
+### Changed
+- Configure k8s service load_balancer_source_ranges.
+
 ## [3.0.0] - 2019-11-12
 
 ### Added

--- a/k8s.tf
+++ b/k8s.tf
@@ -83,6 +83,7 @@ resource "kubernetes_service" "waggle_dance" {
       port        = 48869
       target_port = 48869
     }
-    type = "LoadBalancer"
+    type                        = "LoadBalancer"
+    load_balancer_source_ranges = var.ingress_cidr
   }
 }


### PR DESCRIPTION
load_balancer_source_ranges defaults to 0.0.0.0/0
https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer

configuring this so that worker security group wont be flagged for 0.0.0.0/0 ingress rule.
