### PR TITLE
Add LB Listener and Point to Prometheus TG

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -154,7 +154,7 @@ resource "aws_lb_listener" "waggledance-prometheus" {
   port              = 18000
 
   default_action {
-    target_group_arn = aws_lb_target_group.waggledance[0].arn
+    target_group_arn = aws_lb_target_group.waggledance_prometheus[0].arn
     type             = "forward"
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -117,7 +117,7 @@ resource "aws_lb_target_group" "waggledance" {
   }
 }
 
-resource "aws_lb_target_group" "waggledance" {
+resource "aws_lb_target_group" "waggledance_prometheus" {
   count       = var.wd_instance_type == "ecs" && var.enable_autoscaling ? 1 : 0
   port        = 18000
   protocol    = "TCP"

--- a/ecs.tf
+++ b/ecs.tf
@@ -117,11 +117,41 @@ resource "aws_lb_target_group" "waggledance" {
   }
 }
 
+resource "aws_lb_target_group" "waggledance" {
+  count       = var.wd_instance_type == "ecs" && var.enable_autoscaling ? 1 : 0
+  port        = 18000
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+  health_check {
+    protocol = "HTTP"
+    port     = 18000
+    path     = "/actuator/health"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_lb_listener" "waggledance" {
   count             = var.wd_instance_type == "ecs" && var.enable_autoscaling ? 1 : 0
   load_balancer_arn = aws_lb.waggledance[0].arn
   protocol          = "TCP"
   port              = local.wd_port
+
+  default_action {
+    target_group_arn = aws_lb_target_group.waggledance[0].arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "waggledance-prometheus" {
+  count             = var.wd_instance_type == "ecs" && var.enable_autoscaling ? 1 : 0
+  load_balancer_arn = aws_lb.waggledance[0].arn
+  protocol          = "TCP"
+  port              = 18000
 
   default_action {
     target_group_arn = aws_lb_target_group.waggledance[0].arn


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Create a LoadBalancer along with a TargetGroup that points to Prometheus to tackle autoscaling on the WD instances.

### :link: Related Issues
- 
