### PR TITLE
Waggledance secondary vpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2022-08-15
+### Changed
+- Add secondary vpc support for waggledance route53 zone with autoscaling.
+
 ## [4.0.1] - 2022-07-20
 ### Changed
 - Add waggle-dance load balancer output when using ECS and autoscaling.

--- a/route53.tf
+++ b/route53.tf
@@ -11,6 +11,10 @@ resource "aws_route53_zone" "waggledance" {
   vpc {
     vpc_id = var.vpc_id
   }
+  
+  lifecycle {
+    ignore_changes = [vpc]
+  }
 }
 
 resource "aws_route53_record" "metastore_proxy" {

--- a/route53.tf
+++ b/route53.tf
@@ -22,3 +22,11 @@ resource "aws_route53_record" "metastore_proxy" {
   ttl     = "300"
   records = var.wd_instance_type == "k8s" ? kubernetes_service.waggle_dance[0].load_balancer_ingress.*.hostname : [aws_lb.waggledance[0].dns_name]
 }
+
+resource "aws_route53_zone_association" "waggledance_secondary_vpc" {
+  count      = var.enable_autoscaling ? length(var.secondary_vpcs) : 0
+  
+  zone_id    = aws_route53_zone.waggledance[0].id
+  vpc_id     = var.secondary_vpcs[count.index]
+  vpc_region = var.aws_region
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Add support for secondary vpc to waggledance route53 zone with autoscaling.

### :link: Related Issues
- 
