### PR TITLE
Fix/health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.1.3] - 2023-11-08
+### Fixed
+- ECS healtcheck endpoints, switched back to `/actuator/health`
+
 ## [4.1.2] - 2023-09-06
 ### Added
 - Metrics have been incorporated into Waggle Dance with the inclusion of tags, which will facilitate filtering within Datadog.

--- a/ecs.tf
+++ b/ecs.tf
@@ -113,8 +113,6 @@ resource "aws_lb_target_group" "waggledance" {
     protocol = "HTTP"
     port     = 18000
     path     = "/actuator/health/liveness"
-    interval = 30
-    timeout  = 10
   }
 
   lifecycle {

--- a/ecs.tf
+++ b/ecs.tf
@@ -112,7 +112,7 @@ resource "aws_lb_target_group" "waggledance" {
   health_check {
     protocol = "HTTP"
     port     = 18000
-    path     = "/actuator/health/liveness"
+    path     = "/actuator/health"
   }
 
   lifecycle {

--- a/ecs.tf
+++ b/ecs.tf
@@ -113,6 +113,8 @@ resource "aws_lb_target_group" "waggledance" {
     protocol = "HTTP"
     port     = 18000
     path     = "/actuator/health/liveness"
+    interval = 30
+    timeout  = 10
   }
 
   lifecycle {

--- a/templates/waggledance.json
+++ b/templates/waggledance.json
@@ -25,11 +25,11 @@
 	  },
 	  {
 		"name": "LOGLEVEL",
-		"value": "debug"
+		"value": "${loglevel}"
 	  },
 	  {
 		"name": "INVOCATIONLOGLEVEL",
-		"value": "debug"
+		"value": "${invocationloglevel}"
 	  },
 	  {
 		"name": "SERVER_YAML",
@@ -54,7 +54,7 @@
 	],
 	"healthCheck": {
 	  "command": ["CMD-SHELL", "curl -f http://localhost:18000/actuator/health || exit 1"],
-	  "interval": 30,
+	  "interval": 5,
 	  "retries": 3,
 	  "startPeriod": 60,
 	  "timeout": 5

--- a/templates/waggledance.json
+++ b/templates/waggledance.json
@@ -25,7 +25,7 @@
 	  },
 	  {
 		"name": "LOGLEVEL",
-		"value": "${loglevel}"
+		"value": "debug"
 	  },
 	  {
 		"name": "INVOCATIONLOGLEVEL",
@@ -53,10 +53,10 @@
 	  }
 	],
 	"healthCheck": {
-	  "command": ["CMD-SHELL", "curl -f http://localhost:18000/actuator/health/liveness || exit 1"],
+	  "command": ["CMD-SHELL", "curl -f http://localhost:18000/actuator/health || exit 1"],
 	  "interval": 30,
 	  "retries": 3,
-	  "startPeriod": 120,
+	  "startPeriod": 60,
 	  "timeout": 5
 	},
 	"ulimits": [

--- a/templates/waggledance.json
+++ b/templates/waggledance.json
@@ -54,9 +54,9 @@
 	],
 	"healthCheck": {
 	  "command": ["CMD-SHELL", "curl -f http://localhost:18000/actuator/health/liveness || exit 1"],
-	  "interval": 5,
+	  "interval": 30,
 	  "retries": 3,
-	  "startPeriod": 60,
+	  "startPeriod": 120,
 	  "timeout": 5
 	},
 	"ulimits": [

--- a/templates/waggledance.json
+++ b/templates/waggledance.json
@@ -29,7 +29,7 @@
 	  },
 	  {
 		"name": "INVOCATIONLOGLEVEL",
-		"value": "${invocationloglevel}"
+		"value": "debug"
 	  },
 	  {
 		"name": "SERVER_YAML",


### PR DESCRIPTION
the endpoint `/actuator/health` works in ECS even with new springboot.
In EKS for some reason returns 503 (down) for us this is a different issue we'll need to investigate but for now I'd like to unblock the ECS deployments.
