### PR TITLE
feature/fix dd provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.3.2] - 2024-03-26
+### Updated
+- Removed the datadog explicit provider configuration as suggested here: https://developer.hashicorp.com/terraform/language/modules/develop/providers#legacy-shared-modules-with-provider-configurations
+
 ## [4.3.1] - 2024-02-22
 ### Updated
 - Updated eks to use instance name instead of hard coding.

--- a/common.tf
+++ b/common.tf
@@ -64,8 +64,3 @@ data "external" "datadog_key" {
   count = length(var.datadog_key_secret_name) > 0 ? 1 : 0
   program = ["echo", "${data.aws_secretsmanager_secret_version.datadog_key[0].secret_string}"]
 }
-
-provider "datadog" {
-  api_key  = chomp(data.external.datadog_key[0].result["api_key"])
-  app_key  = chomp(data.external.datadog_key[0].result["app_key"])
-}


### PR DESCRIPTION
- we cannot have providers in modules and use count on module invocation to conditionally enable the module on or off as per https://developer.hashicorp.com/terraform/language/modules/develop/providers#legacy-shared-modules-with-provider-configurationsWq
- update CHANGELOG

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- 

### :link: Related Issues
- 
