### PR TITLE
fix: Enable Datadog filtering for WD metrics

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -7,6 +7,7 @@
 locals {
   instance_alias               = var.instance_name == "" ? "waggledance" : format("waggledance-%s", var.instance_name)
   remote_metastore_zone_prefix = var.instance_name == "" ? "remote-metastore" : format("remote-metastore-%s", var.instance_name)
+  datadog_tags = join(" ", formatlist("%s:%s", keys(module.tags), values(module.tags)))
 }
 
 data "aws_caller_identity" "current" {}

--- a/templates.tf
+++ b/templates.tf
@@ -7,6 +7,7 @@
 locals {
   default_exposed_endpoints = "health,info,metrics"
   exposed_endpoints         = var.prometheus_enabled ? join(",", [local.default_exposed_endpoints, "prometheus"]) : local.default_exposed_endpoints
+  datadog_tags              = local.datadog_tags
 }
 
 data "template_file" "endpoints_server_yaml" {

--- a/templates/datadog-agent.json
+++ b/templates/datadog-agent.json
@@ -19,6 +19,10 @@
     {
       "name": "ECS_FARGATE",
       "value": "true"
+    },
+    {
+        "name": "DD_TAGS",
+        "value": "${datadog_tags}"
     }
   ],
   "healthCheck": {


### PR DESCRIPTION
### :pencil: Enable Datadog filtering for WD metrics on ECS using tags

### :link: https://jira.expedia.biz/browse/EGANP-2967
