### PR TITLE
Use string concatenation to fix current template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.6.3] - 2025-02-13
+### Added
+- Use string concatenation `~` to fix current federation template.
+
 ## [4.6.2] - 2025-02-12
 ### Added
 - Use single quotes when empty to instantiate empty prefix.

--- a/templates/waggle-dance-federation-glue.yml.tmpl
+++ b/templates/waggle-dance-federation-glue.yml.tmpl
@@ -1,7 +1,7 @@
 %{if metastore_enabled~}
   - name: ${ name == "" ? prefix : name }
     access-control-type: ${ writable_whitelist == "" ? "READ_ONLY" : "READ_AND_WRITE_ON_DATABASE_WHITELIST" }
-    database-prefix: '${ prefix == "" ? "" : prefix ~ "_" }'
+    database-prefix: '${ prefix == "" ? "" : format("%s_", prefix) }'
     glue-config:
       glue-account-id: ${glue_account_id}
       glue-endpoint: ${glue_endpoint}

--- a/templates/waggle-dance-federation-glue.yml.tmpl
+++ b/templates/waggle-dance-federation-glue.yml.tmpl
@@ -1,7 +1,7 @@
 %{if metastore_enabled~}
-  - name: ${ name == "" ? "prefix" : "name" }
+  - name: ${ name == "" ? prefix : name }
     access-control-type: ${ writable_whitelist == "" ? "READ_ONLY" : "READ_AND_WRITE_ON_DATABASE_WHITELIST" }
-    database-prefix: '${ prefix == "" ? "" : "prefix_" }'
+    database-prefix: '${ prefix == "" ? "" : prefix ~ "_" }'
     glue-config:
       glue-account-id: ${glue_account_id}
       glue-endpoint: ${glue_endpoint}

--- a/templates/waggle-dance-federation-local.yml.tmpl
+++ b/templates/waggle-dance-federation-local.yml.tmpl
@@ -1,7 +1,7 @@
 %{if metastore_enabled~}
-  - name: ${ name == "" ? "prefix" : "name" }
+  - name: ${ name == "" ? prefix : name }
     access-control-type: ${ writable_whitelist == "" ? "READ_ONLY" : "READ_AND_WRITE_ON_DATABASE_WHITELIST" }
-    database-prefix: '${ prefix == "" ? "" : "prefix_" }'
+    database-prefix: '${ prefix == "" ? "" : prefix ~ "_" }'
     remote-meta-store-uris: thrift://${metastore_host}:${metastore_port}
     latency: ${latency}
 %{if enable_path_conversion ~}

--- a/templates/waggle-dance-federation-local.yml.tmpl
+++ b/templates/waggle-dance-federation-local.yml.tmpl
@@ -1,7 +1,7 @@
 %{if metastore_enabled~}
   - name: ${ name == "" ? prefix : name }
     access-control-type: ${ writable_whitelist == "" ? "READ_ONLY" : "READ_AND_WRITE_ON_DATABASE_WHITELIST" }
-    database-prefix: '${ prefix == "" ? "" : prefix ~ "_" }'
+    database-prefix: '${ prefix == "" ? "" : format("%s_", prefix) }'
     remote-meta-store-uris: thrift://${metastore_host}:${metastore_port}
     latency: ${latency}
 %{if enable_path_conversion ~}

--- a/templates/waggle-dance-federation-remote.yml.tmpl
+++ b/templates/waggle-dance-federation-remote.yml.tmpl
@@ -1,7 +1,7 @@
 %{if metastore_enabled~}
-  - name: ${ name == "" ? "prefix" : "name" }
+  - name: ${ name == "" ? prefix : name }
     access-control-type: ${ writable_whitelist == "" ? "READ_ONLY" : "READ_AND_WRITE_ON_DATABASE_WHITELIST" }
-    database-prefix: '${ prefix == "" ? "" : "prefix_" }'
+    database-prefix: '${ prefix == "" ? "" : prefix ~ "_" }'
     remote-meta-store-uris: thrift://${metastore_host}:${metastore_port}
     latency: ${latency}
 %{if enable_path_conversion ~}

--- a/templates/waggle-dance-federation-remote.yml.tmpl
+++ b/templates/waggle-dance-federation-remote.yml.tmpl
@@ -1,7 +1,7 @@
 %{if metastore_enabled~}
   - name: ${ name == "" ? prefix : name }
     access-control-type: ${ writable_whitelist == "" ? "READ_ONLY" : "READ_AND_WRITE_ON_DATABASE_WHITELIST" }
-    database-prefix: '${ prefix == "" ? "" : prefix ~ "_" }'
+    database-prefix: '${ prefix == "" ? "" : format("%s_", prefix) }'
     remote-meta-store-uris: thrift://${metastore_host}:${metastore_port}
     latency: ${latency}
 %{if enable_path_conversion ~}

--- a/templates/waggle-dance-federation-ssh.yml.tmpl
+++ b/templates/waggle-dance-federation-ssh.yml.tmpl
@@ -1,7 +1,7 @@
 %{if metastore_enabled~}
   - name: ${ name == "" ? prefix : name }
     access-control-type: ${ writable_whitelist == "" ? "READ_ONLY" : "READ_AND_WRITE_ON_DATABASE_WHITELIST" }
-    database-prefix: ${ prefix == "" ? '' : "prefix_" }
+    database-prefix: '${ prefix == "" ? "" : format("%s_", prefix) }'
     remote-meta-store-uris: thrift://${metastore_host}:${metastore_port}
     latency: ${latency}
     metastore-tunnel:

--- a/templates/waggle-dance-federation-ssh.yml.tmpl
+++ b/templates/waggle-dance-federation-ssh.yml.tmpl
@@ -1,5 +1,5 @@
 %{if metastore_enabled~}
-  - name: ${ name == "" ? "prefix" : "name" }
+  - name: ${ name == "" ? prefix : name }
     access-control-type: ${ writable_whitelist == "" ? "READ_ONLY" : "READ_AND_WRITE_ON_DATABASE_WHITELIST" }
     database-prefix: ${ prefix == "" ? '' : "prefix_" }
     remote-meta-store-uris: thrift://${metastore_host}:${metastore_port}

--- a/templates/waggle-dance-federation.yml.tmpl
+++ b/templates/waggle-dance-federation.yml.tmpl
@@ -1,6 +1,6 @@
 primary-meta-store:
   access-control-type: ${primary_metastore_access_type}
-  database-prefix: '${ primary_metastore_database_prefix == "" ? "" : "primary_metastore_database_prefix_" }'
+  database-prefix: '${ primary_metastore_database_prefix == "" ? "" : primary_metastore_database_prefix ~ "_" }'
   name: primary
 %{if primary_metastore_glue_account_id != "" ~}
   glue-config:

--- a/templates/waggle-dance-federation.yml.tmpl
+++ b/templates/waggle-dance-federation.yml.tmpl
@@ -1,6 +1,6 @@
 primary-meta-store:
   access-control-type: ${primary_metastore_access_type}
-  database-prefix: '${ primary_metastore_database_prefix == "" ? "" : primary_metastore_database_prefix ~ "_" }'
+  database-prefix: '${ primary_metastore_database_prefix == "" ? "" : format("%s_", primary_metastore_database_prefix) }'
   name: primary
 %{if primary_metastore_glue_account_id != "" ~}
   glue-config:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Use string concatenation `~` to fix current federation template.
- Currently if prefix=catalog_A it returns prefix_ instead of catalog_A_

### :link: Related Issues
- 
