### PR TITLE
fix: grant read access to Glue column statistics for Waggledance ECS role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.9.0] - 2026-07-22
+### Added
+- Added `glue:GetColumnStatisticsForTable` and `glue:GetColumnStatisticsForPartition` to the Glue read policy
+- Added `glue:UpdateColumnStatisticsForTable`, `glue:DeleteColumnStatisticsForTable`, `glue:UpdateColumnStatisticsForPartition`, and `glue:DeleteColumnStatisticsForPartition` to the Glue write policy
+- Without these, column statistics written via `ANALYZE` against a federated Glue metastore could not be read back (or written) through Waggle Dance, even though standard table/partition access worked fine
+
 ## [4.8.0] - 2025-11-12
 ### Added
 - Added optional glue write policy

--- a/common.tf
+++ b/common.tf
@@ -83,7 +83,11 @@ data "aws_iam_policy_document" "waggle_dance_remote_glue_federations_policy_writ
       "glue:UpdateTable",
       "glue:BatchUpdatePartition",
       "glue:BatchDeletePartition",
-      "glue:BatchCreatePartition"
+      "glue:BatchCreatePartition",
+      "glue:UpdateColumnStatisticsForTable",
+      "glue:DeleteColumnStatisticsForTable",
+      "glue:UpdateColumnStatisticsForPartition",
+      "glue:DeleteColumnStatisticsForPartition"
     ]
     resources = [
       for glue_account_id in local.glue_account_ids:

--- a/common.tf
+++ b/common.tf
@@ -59,7 +59,9 @@ data "aws_iam_policy_document" "waggle_dance_remote_glue_federations_policy_read
       "glue:GetPartitions",
       "glue:BatchGetPartition",
       "glue:GetUserDefinedFunction",
-      "glue:GetUserDefinedFunctions"
+      "glue:GetUserDefinedFunctions",
+      "glue:GetColumnStatisticsForTable",
+      "glue:GetColumnStatisticsForPartition"
     ]
     resources = [
       for glue_account_id in local.glue_account_ids:


### PR DESCRIPTION
## Summary
- `waggle_dance_remote_glue_federations_policy_read`/`_write` (common.tf) grant the Waggledance ECS task role table/partition metadata actions (`GetTable`, `CreateTable`, `UpdatePartition`, etc.) but never any `glue:*ColumnStatistics*` actions.
- Trino writes/reads column statistics via the same Glue Data Catalog column-statistics API (`ANALYZE` calls `UpdateColumnStatisticsForTable`; query planning calls `GetColumnStatisticsForTable`) — separate from the table/partition metadata API. Without these actions, any Waggledance instance federating to a Glue metastore can't read or write column statistics, even though standard table/partition access works fine.
- This PR adds:
  - **Read policy**: `glue:GetColumnStatisticsForTable`, `glue:GetColumnStatisticsForPartition`
  - **Write policy**: `glue:UpdateColumnStatisticsForTable`, `glue:DeleteColumnStatisticsForTable`, `glue:UpdateColumnStatisticsForPartition`, `glue:DeleteColumnStatisticsForPartition`
- Mirrors the existing table/partition split already used in this module (Get* on read, Create/Update/Delete* on write).

## Test plan
- [ ] `terraform plan` on a consumer of this module shows only a diff to the two existing policy documents (no resource replacement)
- [ ] After deploy, a Trino `ANALYZE` through a Waggledance-fronted Glue-federated schema successfully writes column statistics, and `SHOW STATS` on another cluster through the same Waggledance instance reads them back